### PR TITLE
Import only scss/sass files

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,9 @@ module.exports = function() {
             });
             return replaceString;
         } else {
-            return '@import "' + filename + '";\n'
+            if (filename.substr(-4).match(/sass|scss/i)) {
+                return '@import "' + filename + '";\n'
+            }
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ module.exports = function() {
         } else {
             if (filename.substr(-4).match(/sass|scss/i)) {
                 return '@import "' + filename + '";\n'
+            } else {
+                return '';
             }
         }
     }


### PR DESCRIPTION
I'm trying to make modules and store all module's related stuff in the same directory (styles, images, js). 

\* imports all of them, so we need to check file extension before import.