### PR TITLE
Allow to use single quotes in import

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function() {
         // find all instances matching
         var contents = file.contents.toString('utf-8');
 
-        var reg = /@import\s+\"([^\"]*\*[^\"]*)\"/;
+        var reg = /@import\s+[\"']([^\"']*\*[^\"']*)[\"']/;
         var result;
 
         while((result = reg.exec(contents)) !== null) {


### PR DESCRIPTION
It doesn't work with single quotes now. `@import 'folder/*'` throw an error.

I've made the PR to let you check my commit to be sure that everything is ok.
