### PR TITLE
Forced path concat to use Unix-style delimiter

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function() {
             if (path.basename(filename).substring(0, 1) == '_') return '';
             
             fs.readdirSync(filename).forEach(function (file) {
-                replaceString += process(filename + path.sep + file);
+                replaceString += process(filename + '/' + file);
             });
             return replaceString;
         } else {


### PR DESCRIPTION
Changed concat to always use Unix-style delimiters. This was causing an error on Windows where normal Sass path syntax (Unix-style) was being mixed with Window's '\' delimiter, creating invalid paths like '/foo/bar\baz'.

For reference on Windows using Unix paths in Sass, check out http://www.sascommunity.org/wiki/Tips:Specifying_directory_paths_that_work_on_Window_and_Unix
